### PR TITLE
Corrected missing/broken SKOS:narrower for various ProductTypes

### DIFF
--- a/productTypes.json
+++ b/productTypes.json
@@ -340,6 +340,8 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#gooseberry"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#raspberry"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#strawberry"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -1440,6 +1442,8 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#grain"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#seed"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#pulse"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -1980,6 +1984,8 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#prune"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#quince"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#medlar"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -2788,6 +2794,8 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#savory-groceries"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#sweet-groceries"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#dried_goods"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -4052,8 +4060,6 @@
     "http://www.w3.org/2004/02/skos/core#narrower" : [ {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#chicory"
     }, {
-      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#chewed-up"
-    }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cress"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#dandelion"
@@ -4069,6 +4075,8 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#salad-mix"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#spinach"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#corn-salad"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -4174,6 +4182,14 @@
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#salt"
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#semolina"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#grain"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cannedGoods"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#snack"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#ferment"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "en",
@@ -4808,9 +4824,9 @@
     }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cluster-tomato"
     }, {
-      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#old-variety-tomato"
-    }, {
       "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#round-tomato"
+    }, {
+      "@id" : "https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#hierloom-tomato"
     } ],
     "http://www.w3.org/2004/02/skos/core#prefLabel" : [ {
       "@language" : "fr",

--- a/productTypes.rdf
+++ b/productTypes.rdf
@@ -105,6 +105,7 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#plum"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#prune"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#quince"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#medlar"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#inedible">
@@ -129,6 +130,7 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#ready-meal"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#savory-groceries"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#sweet-groceries"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#dried_goods"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#meat-product">
@@ -358,6 +360,7 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#currant"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#gooseberry"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#raspberry"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#strawberry"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cherry">
@@ -561,6 +564,10 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#rice"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#salt"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#semolina"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#grain"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cannedGoods"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#snack"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#ferment"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#sweet-groceries">
@@ -963,7 +970,6 @@
 	<skos:prefLabel xml:lang="fr">salade</skos:prefLabel>
 	<skos:broader rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#vegetable"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#chicory"/>
-	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#chewed-up"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cress"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#dandelion"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#endive"/>
@@ -972,6 +978,7 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#rocket"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#salad-mix"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#spinach"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#corn-salad"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#salsify">
@@ -1011,8 +1018,8 @@
 	<skos:broader rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#vegetable"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cherry-tomato"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#cluster-tomato"/>
-	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#old-variety-tomato"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#round-tomato"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#hierloom-tomato"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#turnip">
@@ -2221,6 +2228,7 @@
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#flake"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#grain"/>
 	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#seed"/>
+	<skos:narrower rdf:resource="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#pulse"/>
 </rdf:Description>
 
 <rdf:Description rdf:about="https://github.com/datafoodconsortium/taxonomies/releases/latest/download/productTypes.rdf#dried_herb">


### PR DESCRIPTION
Small changes to ProductTypes files to facilitate Connector functionality. related to [TS issue #5](https://github.com/datafoodconsortium/connector-typescript/issues/5).  

### Detailed change log:

- Added `medlar` as narrower of `fruit`
- Added `strawberry` as narrower of `fruit`
- Added `pulse` as narrower of `dried_goods`
- Replaced `chewed-up` with `corn-salad` as narrower of `salad`
- Replaced `old-variety-tomato` with `heirloom-tomato` as narrower of `tomato`
- Added `snack` as narrower of `savory-groceries`
- Added `grain` as narrower of `savory-groceries`
- Added `cannedGoods` as narrower of `savory-groceries`
- Added `ferment` as narrower of `savory-groceries`
- Added `dried_goods` as narrower of `local-grocery-store`
